### PR TITLE
Add a makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CC = cc
+CFLAGS=-O2 -fPIC -fstack-protector-strong -D_GNU_SOURCE -s -z norelro
+PREFIX=/usr
+BINDIR=$(PREFIX)/bin
+
+all: tinyionice
+
+tinyionice: main.c
+	$(CC) $(CFLAGS) $< -o $@
+
+install: tinyionice
+	install -D -m 755 tinyionice $(DESTDIR)/$(BINDIR)/tinyionice
+
+uninstall:
+	rm -f $(DESTDIR)/$(BINDIR)/tinyionice
+
+clean:
+	rm -f tinyionice
+
+
+.PHONY: all install uninstall clean


### PR DESCRIPTION
OpenWrt doesn't build ionice as part of busybox, so instead of patching the busybox package, it's nice to have ionice independently installable and this project is perfect for that. I included a patch for the makefile in the package, but it would be nice if this could be accepted upstream.